### PR TITLE
Added necessary explanation to Intro-to-PyTorch notebooks

### DIFF
--- a/intro-to-pytorch/Part 2 - Neural Networks in PyTorch (Exercises).ipynb
+++ b/intro-to-pytorch/Part 2 - Neural Networks in PyTorch (Exercises).ipynb
@@ -348,7 +348,9 @@
     "\n",
     "<img src=\"assets/mlp_mnist.png\" width=600px>\n",
     "\n",
-    "> **Exercise:** Create a network with 784 input units, a hidden layer with 128 units and a ReLU activation, then a hidden layer with 64 units and a ReLU activation, and finally an output layer with a softmax activation as shown above. You can use a ReLU activation with the `nn.ReLU` module or `F.relu` function."
+    "> **Exercise:** Create a network with 784 input units, a hidden layer with 128 units and a ReLU activation, then a hidden layer with 64 units and a ReLU activation, and finally an output layer with a softmax activation as shown above. You can use a ReLU activation with the `nn.ReLU` module or `F.relu` function.\n",
+    "\n",
+    "It's good practice to name your layers by their type of network, for instance 'fc' to represent a fully-connected layer. As you code your solution, use `fc1`, `fc2`, and `fc3` as your layer names."
    ]
   },
   {

--- a/intro-to-pytorch/Part 2 - Neural Networks in PyTorch (Solution).ipynb
+++ b/intro-to-pytorch/Part 2 - Neural Networks in PyTorch (Solution).ipynb
@@ -413,7 +413,9 @@
     "\n",
     "<img src=\"assets/mlp_mnist.png\" width=600px>\n",
     "\n",
-    "> **Exercise:** Create a network with 784 input units, a hidden layer with 128 units and a ReLU activation, then a hidden layer with 64 units and a ReLU activation, and finally an output layer with a softmax activation as shown above. You can use a ReLU activation with the `nn.ReLU` module or `F.relu` function."
+    "> **Exercise:** Create a network with 784 input units, a hidden layer with 128 units and a ReLU activation, then a hidden layer with 64 units and a ReLU activation, and finally an output layer with a softmax activation as shown above. You can use a ReLU activation with the `nn.ReLU` module or `F.relu` function.\n",
+    "\n",
+    "It's good practice to name your layers by their type of network, for instance 'fc' to represent a fully-connected layer. As you code your solution, use `fc1`, `fc2`, and `fc3` as your layer names."
    ]
   },
   {


### PR DESCRIPTION
Part 2 of Intro-to-PyTorch notebooks started to use a naming convention without telling the students to do so or explaining it to the students.

Added text to explain and suggest use.